### PR TITLE
Add `sudo` when connecting to database

### DIFF
--- a/week4.md
+++ b/week4.md
@@ -253,7 +253,7 @@ If s/he “only” crack your user account, s/he will be sandboxed (and can do l
       Note: database root user is not operating system root user! Avoid same password!
    1. Connect to your database:
       ```console
-      $ mysql -u root -p
+      $ sudo mysql -u root -p
       ```
       and create a database and a user with privileges on it:
         ```sql


### PR DESCRIPTION
Access is denied when not using `sudo` with `mysql -u root -p`

`$ mysql -u root -p`
output:
```
Enter password:
ERROR 1698 (28000): Access denied for user 'root'@'localhost'
```
`$ sudo mysql -u root -p`
output:
```
[sudo] password for ubuntu:
Enter password:
Welcome to the MariaDB monitor.  Commands end with ; or \g.
...
```